### PR TITLE
feat: update to key protect 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This module combines the following Key Protect modules to create a full end-to-e
 
 The module takes a map, called `key_map`, that supports hierarchical "key rings" for a single Key Protect instance. Because access to key rings is managed in Key Protect, you can comply with controls around least privilege (for example, [NIST AC-6](https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#/control?version=4.0&number=AC-6)) and can reduce the number of access groups you need to assign. For more information about key rings, see [Grouping keys together using key rings](https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys).
 The following example shows a typical topology for a Key Protect instance:
-
 ```
 ├── cos-key-ring
 │   ├── root-key-cos-bucket-1

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This module combines the following Key Protect modules to create a full end-to-e
 
 The module takes a map, called `key_map`, that supports hierarchical "key rings" for a single Key Protect instance. Because access to key rings is managed in Key Protect, you can comply with controls around least privilege (for example, [NIST AC-6](https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#/control?version=4.0&number=AC-6)) and can reduce the number of access groups you need to assign. For more information about key rings, see [Grouping keys together using key rings](https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys).
 The following example shows a typical topology for a Key Protect instance:
+
 ```
 ├── cos-key-ring
 │   ├── root-key-cos-bucket-1

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ One emerging pattern is to create one Key Protect instance per VPC. All workload
 
 ## Usage
 
-There is currently an [enhancement request](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4256) open with the IBM terraform provider to support enabling metrics. Until then, this module uses the restapi provider to enable metrics.
+Although the restapi provider is currently a required provider for this module, it is no longer used for any function within the module. It will be removed in the next major version release of this module.
 
 ```hcl
 provider "ibm" {
@@ -107,7 +107,7 @@ You need the following permissions to run this module.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_existing_key_ring_keys"></a> [existing\_key\_ring\_keys](#module\_existing\_key\_ring\_keys) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key.git | v1.0.3 |
-| <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git | v1.2.1 |
+| <a name="module_key_protect"></a> [key\_protect](#module\_key\_protect) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git | v1.3.0 |
 | <a name="module_key_protect_key_rings"></a> [key\_protect\_key\_rings](#module\_key\_protect\_key\_rings) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring.git | v2.0.1 |
 | <a name="module_key_protect_keys"></a> [key\_protect\_keys](#module\_key\_protect\_keys) | git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key.git | v1.0.3 |
 
@@ -140,6 +140,7 @@ No resources.
 |------|-------------|
 | <a name="output_existing_key_ring_keys"></a> [existing\_key\_ring\_keys](#output\_existing\_key\_ring\_keys) | IDs of Keys created by the module in existing Key Rings |
 | <a name="output_key_protect_guid"></a> [key\_protect\_guid](#output\_key\_protect\_guid) | Key Protect GUID |
+| <a name="output_key_protect_instance_policies"></a> [key\_protect\_instance\_policies](#output\_key\_protect\_instance\_policies) | Instance Polices of the Key Protect instance |
 | <a name="output_key_protect_name"></a> [key\_protect\_name](#output\_key\_protect\_name) | Key Protect Name |
 | <a name="output_key_rings"></a> [key\_rings](#output\_key\_rings) | IDs of new Key Rings created by the module |
 | <a name="output_keys"></a> [keys](#output\_keys) | IDs of new Keys created by the module |

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -22,6 +22,11 @@ output "key_protect_name" {
   value       = module.key_protect_all_inclusive.key_protect_name
 }
 
+output "key_protect_instance_policies" {
+  description = "Instance Polices of the Key Protect instance"
+  value       = module.key_protect_all_inclusive.key_protect_instance_policies
+}
+
 output "key_rings" {
   description = "IDs of Key Rings created by the module"
   value       = module.key_protect_all_inclusive.key_rings

--- a/examples/existing-resources/main.tf
+++ b/examples/existing-resources/main.tf
@@ -13,7 +13,7 @@ module "resource_group" {
 # Create Key Protect instance outside of terraform-ibm-key-protect-all-inclusive module
 ##############################################################################
 module "existing_key_protect" {
-  source            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.2.1"
+  source            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.3.0"
   resource_group_id = module.resource_group.resource_group_id
   region            = var.region
   tags              = var.resource_tags

--- a/examples/existing-resources/outputs.tf
+++ b/examples/existing-resources/outputs.tf
@@ -22,6 +22,11 @@ output "key_protect_name" {
   value       = module.key_protect_all_inclusive.key_protect_name
 }
 
+output "key_protect_instance_policies" {
+  description = "Instance Polices of the Key Protect instance"
+  value       = module.key_protect_all_inclusive.key_protect_instance_policies
+}
+
 output "key_rings" {
   description = "IDs of Key Rings created by the module"
   value       = module.key_protect_all_inclusive.key_rings

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ locals {
 
 module "key_protect" {
   count             = var.create_key_protect_instance ? 1 : 0
-  source            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.2.1"
+  source            = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.3.0"
   key_protect_name  = var.key_protect_instance_name
   region            = var.region
   service_endpoints = var.key_protect_endpoint_type

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -20,7 +20,7 @@
       "description": "Set to true to enable metrics on the Key Protect instance (ignored is value for 'existing_key_protect_instance_guid' is passed). In order to view metrics, you will need a Monitoring (Sysdig) instance that is located in the same region as the Key Protect instance. Once you provision the Monitoring instance, you will need to enable platform metrics.",
       "default": true,
       "source": [
-        "module.key_protect.restapi_object.enable_metrics.count"
+        "module.key_protect"
       ],
       "pos": {
         "filename": "variables.tf",
@@ -154,12 +154,7 @@
       "description": "The IBM Cloud region where all resources will be provisioned.",
       "required": true,
       "source": [
-        "module.key_protect.ibm_resource_instance.key_protect_instance.location",
-        "module.key_protect.restapi_object.enable_metrics.create_path",
-        "module.key_protect.restapi_object.enable_metrics.destroy_path",
-        "module.key_protect.restapi_object.enable_metrics.path",
-        "module.key_protect.restapi_object.enable_metrics.read_path",
-        "module.key_protect.restapi_object.enable_metrics.update_path"
+        "module.key_protect.ibm_resource_instance.key_protect_instance.location"
       ],
       "pos": {
         "filename": "variables.tf",
@@ -215,7 +210,7 @@
       "value": "module.existing_key_ring_keys",
       "pos": {
         "filename": "outputs.tf",
-        "line": 25
+        "line": 30
       }
     },
     "key_protect_guid": {
@@ -225,6 +220,14 @@
       "pos": {
         "filename": "outputs.tf",
         "line": 5
+      }
+    },
+    "key_protect_instance_policies": {
+      "name": "key_protect_instance_policies",
+      "description": "Instance Polices of the Key Protect instance",
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 15
       }
     },
     "key_protect_name": {
@@ -241,7 +244,7 @@
       "value": "module.key_protect_key_rings",
       "pos": {
         "filename": "outputs.tf",
-        "line": 15
+        "line": 20
       }
     },
     "keys": {
@@ -250,7 +253,7 @@
       "value": "module.key_protect_keys",
       "pos": {
         "filename": "outputs.tf",
-        "line": 20
+        "line": 25
       }
     }
   },
@@ -383,7 +386,7 @@
     },
     "key_protect": {
       "name": "key_protect",
-      "source": "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.2.1",
+      "source": "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect.git?ref=v1.3.0",
       "attributes": {
         "count": "create_key_protect_instance",
         "key_protect_name": "key_protect_instance_name",
@@ -395,6 +398,18 @@
         "tags": "resource_tags"
       },
       "managed_resources": {
+        "ibm_kms_instance_policies.key_protect_instance_policies": {
+          "mode": "managed",
+          "type": "ibm_kms_instance_policies",
+          "name": "key_protect_instance_policies",
+          "provider": {
+            "name": "ibm"
+          },
+          "pos": {
+            "filename": ".terraform/modules/key_protect/main.tf",
+            "line": 19
+          }
+        },
         "ibm_resource_instance.key_protect_instance": {
           "mode": "managed",
           "type": "ibm_resource_instance",
@@ -413,26 +428,6 @@
           "pos": {
             "filename": ".terraform/modules/key_protect/main.tf",
             "line": 5
-          }
-        },
-        "restapi_object.enable_metrics": {
-          "mode": "managed",
-          "type": "restapi_object",
-          "name": "enable_metrics",
-          "attributes": {
-            "count": "metrics_enabled",
-            "create_path": "region",
-            "destroy_path": "region",
-            "path": "region",
-            "read_path": "region",
-            "update_path": "region"
-          },
-          "provider": {
-            "name": "restapi"
-          },
-          "pos": {
-            "filename": ".terraform/modules/key_protect/main.tf",
-            "line": 20
           }
         }
       },
@@ -455,6 +450,15 @@
           "pos": {
             "filename": ".terraform/modules/key_protect/outputs.tf",
             "line": 10
+          }
+        },
+        "key_protect_instance_policies": {
+          "name": "key_protect_instance_policies",
+          "description": "Instance Polices of the Key Protect instance",
+          "value": "ibm_kms_instance_policies.key_protect_instance_policies",
+          "pos": {
+            "filename": ".terraform/modules/key_protect/outputs.tf",
+            "line": 20
           }
         },
         "key_protect_name": {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,6 +12,11 @@ output "key_protect_name" {
   value       = length(module.key_protect) > 0 ? module.key_protect[0].key_protect_name : null
 }
 
+output "key_protect_instance_policies" {
+  description = "Instance Polices of the Key Protect instance"
+  value       = length(module.key_protect) > 0 ? module.key_protect[0].key_protect_instance_policies : null
+}
+
 output "key_rings" {
   description = "IDs of new Key Rings created by the module"
   value       = module.key_protect_key_rings


### PR DESCRIPTION
### Description

Upgrade key protect module to v1.3.0 to consume new version and add output of key protect instance policies

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [x] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

feat: use ibm provider to enable metrics instead of restapi provider. Also exposed new output key_protect_instance_policies

NOTE: If upgrading to this version, you will see a destroy of the following resource identified `module.key_protect_all_inclusive.module.key_protect[0].restapi_object.enable_metrics[0]` however this does not actually mean metrics will be disabled. Instead it is now going to be managed by the ibm provider. At no point during upgrader will metrics be disabled. 

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
