### PR TITLE
fix: add sleep for destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,12 @@ module "key_protect" {
 # Key Protect Key Rings
 ##############################################################################
 
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [module.module.key_protect_keys]
+
+  destroy_duration = "30s"
+}
+
 # Create Key Rings included in var.existing_key_map
 module "key_protect_key_rings" {
   source        = "git::https://github.com/terraform-ibm-modules/terraform-ibm-key-protect-key-ring.git?ref=v2.0.1"
@@ -54,6 +60,7 @@ module "key_protect_key_rings" {
   instance_id   = local.key_protect_guid
   endpoint_type = var.key_ring_endpoint_type
   key_ring_id   = each.key
+  depends_on = [time_sleep.wait_30_seconds]
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

Add sleep so keys get destroyed before rings.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
